### PR TITLE
feat: store and display http status codes

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -62,6 +62,7 @@ class SEOCrawler(scrapy.Spider):
 
             item = PageItem()
             item['url'] = response.url
+            item['status_code'] = response.status
             item['title'] = sel.xpath("//title/text()").get(default="N/A").strip()
             item['meta_description'] = sel.xpath("//meta[@name='description']/@content").get(default="N/A").strip()
             item['canonical'] = sel.xpath("//link[@rel='canonical']/@href").get(default="N/A").strip()

--- a/items.py
+++ b/items.py
@@ -11,3 +11,4 @@ class PageItem(scrapy.Item):
     image_alts = scrapy.Field()
     json_ld = scrapy.Field()
     broken_links = scrapy.Field()
+    status_code = scrapy.Field()

--- a/pipelines.py
+++ b/pipelines.py
@@ -16,6 +16,7 @@ class SqlitePipeline:
             self.cursor.execute("""
                 CREATE TABLE IF NOT EXISTS pages (
                     url TEXT PRIMARY KEY,
+                    status_code INTEGER,
                     title TEXT,
                     meta_description TEXT,
                     canonical TEXT,
@@ -45,12 +46,13 @@ class SqlitePipeline:
             self.cursor.execute(
                 """
                 INSERT OR REPLACE INTO pages (
-                    url, title, meta_description, canonical, h1_tags, h2_tags,
+                    url, status_code, title, meta_description, canonical, h1_tags, h2_tags,
                     h3_tags, image_alts, json_ld, broken_links
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     item.get('url'),
+                    item.get('status_code'),
                     item.get('title'),
                     item.get('meta_description'),
                     item.get('canonical'),


### PR DESCRIPTION
- Adds a `status_code` field to the `PageItem` and the database schema.
- The crawler now captures the HTTP status code for each response.
- This allows users to see the status code for each crawled URL in the results, helping to identify redirects and errors.